### PR TITLE
adding _operation_type to document when syncing

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -903,7 +903,6 @@ class Sync(Base, metaclass=Singleton):
                     doc["_type"] = "_doc"
 
                 if settings.KAFKA_ENABLED:
-                    doc["_source"] = {}
                     self.publish_to_kafka(doc, payload.xmin)
 
                 docs.append(doc)


### PR DESCRIPTION
Currently, only the changed records are published to kafka as an event without the trigger operation type (INSERT / UPDATE / DELETE / TRUNCATE) mentioned in the document

This hinders any conditional processing to be done to the records consumed from kafka based on the operation performed.
So this change introduces a key `_operation_type` to the pgsync document which is then published to kafka - mentioning the operation done i.e `INSERT`, `UPDATE`, `DELETE` or `TRUNCATE`

Since `delete` operation does not involve any new record - filters are not built, resulting in no matching document and hence nothing is synced. 
This is handled by explicitly publishing to kafka when a record is deleted in order to ensure syncing.

Logs:

**For DELETE**
```
2025-04-30T05:10:21.913284: Sync pgsync:sample Xlog: [0] => Db: [1] => Redis: [0] => OpenSearch: [99] => skip-Xlog: [0] => skip-Redis: [0] => Events: [1]
2025-04-30 05:10:22.183:poll_db:DEBUG:pgsync.sync: should_skip_event: validating event: {'xmin': 5659, 'new': None, 'old': {'id': '12345'}, 'indices': ['sample1', 'sample2', 'sample3'], 'tg_op': 'DELETE', 'table': 'identities', 'schema': 'test', 'changed_fields': None}
2025-04-30 05:10:22.183:poll_db:DEBUG:pgsync.sync: added to payloads from database: {'xmin': 5659, 'new': None, 'old': {'id': '12345'}, 'indices': ['sample1', 'sample2', 'sample3'], 'tg_op': 'DELETE', 'table': 'identities', 'schema': 'test', 'changed_fields': None}
2025-04-30 05:10:22.288:poll_redis-17 (wrapper):DEBUG:pgsync.redisqueue: pop size: 1
2025-04-30 05:10:22.287:poll_redis-17 (wrapper):DEBUG:pgsync.sync: _poll_redis: [{'xmin': 5659, 'new': None, 'old': {'id': '12345'}, 'indices': ['sample1', 'sample2', 'sample3'], 'tg_op': 'DELETE', 'table': 'identities', 'schema': 'test', 'changed_fields': None}]
2025-04-30 05:10:22.288:poll_redis-17 (wrapper):DEBUG:pgsync.sync: on_publish len 1
2025-04-30 05:10:22.288:poll_redis-16 (wrapper):DEBUG:pgsync.redisqueue: pop size: 0
2025-04-30 05:10:22.290:Thread-32 (_handle_tasks):DEBUG:pgsync.sync: about to sync changes from table: test.identities, changes: [Payload("tg_op: DELETE, table: identities, schema: test, old: {'id': '12345'}, new: {}, xmin: 5659, indices: ['sample1', 'sample2', 'sample3'], changed_fields: None}]
2025-04-30 05:10:22.290:Thread-32 (_handle_tasks):DEBUG:pgsync.sync: tg_op: DELETE table: test.identities
2025-04-30 05:10:22.290:Thread-32 (_handle_tasks):DEBUG:pgsync.sync: In publish_to_kafka, recieved tg_op: DELETE
2025-04-30 05:10:22.311:Thread-34 (worker):INFO:opensearch: POST http://elasticsearch:9200/_bulk?refresh=false [status:200 request:0.019s]
2025-04-30T05:10:22.414043: Sync pgsync:sample Xlog: [0] => Db: [2] => Redis: [0] => OpenSearch: [100] => skip-Xlog: [0] => skip-Redis: [0] => Events: [2]
```

**For INSERT**
```
2025-04-30T05:09:40.854854: Sync pgsync:sample Xlog: [0] => Db: [0] => Redis: [0] => OpenSearch: [98] => skip-Xlog: [0] => skip-Redis: [0] => Events: [0]
2025-04-30 05:09:41.054:poll_db:DEBUG:pgsync.sync: should_skip_event: validating event: {'xmin': 5659, 'new': {'id': '12345', 'user_id': '98765'}, 'old': None, 'indices': ['sample1', 'sample2', 'sample3'], 'tg_op': 'INSERT', 'table': 'identities', 'schema': 'test', 'changed_fields': None}
2025-04-30 05:09:41.054:poll_db:DEBUG:pgsync.sync: added to payloads from database: {'xmin': 5659, 'new': {'id': '12345', 'user_id': '98765'}, 'old': None, 'indices': ['sample1', 'sample2', 'sample3'], 'tg_op': 'INSERT', 'table': 'identities', 'schema': 'test', 'changed_fields': None}
2025-04-30 05:09:41.157:poll_redis-17 (wrapper):DEBUG:pgsync.redisqueue: pop size: 0
2025-04-30 05:09:41.158:poll_redis-16 (wrapper):DEBUG:pgsync.redisqueue: pop size: 1
2025-04-30 05:09:41.158:poll_redis-16 (wrapper):DEBUG:pgsync.sync: _poll_redis: [{'xmin': 5659, 'new': {'id': '12345', 'job_id': '98765'}, 'old': None, 'indices': ['sample1', 'sample2', 'sample3'], 'tg_op': 'INSERT', 'table': 'identities', 'schema': 'test', 'changed_fields': None}]
2025-04-30 05:09:41.165:poll_redis-16 (wrapper):DEBUG:pgsync.sync: on_publish len 1
2025-04-30 05:09:41.167:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: about to sync changes from table: test.identities, changes: [Payload("tg_op: INSERT, table: identities, schema: test, old: {}, new: {'id': '12345', 'user_id': '98765'}, xmin: 5659, indices: ['sample1', 'sample2', 'sample3'], changed_fields: None}]
2025-04-30 05:09:41.168:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: tg_op: INSERT table: test.identities
2025-04-30 05:09:41.168:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: _payloads(): calling sync with tg_op=INSERT
2025-04-30 05:09:41.168:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: sync(): recieved tg_op: INSERT
2025-04-30 05:09:41.176:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: sync started: 1 documents to sync
2025-04-30 05:09:41.181:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: Publishing doc to Kafka with tg_op: INSERT
2025-04-30 05:09:41.182:Thread-25 (_handle_tasks):DEBUG:pgsync.sync: In publish_to_kafka, recieved tg_op: INSERT
2025-04-30 05:09:41.193:Thread-20 (worker):INFO:opensearch: POST http://elasticsearch:9200/_bulk?refresh=false [status:200 request:0.011s]
2025-04-30T05:09:41.356512: Sync pgsync.sample Xlog: [0] => Db: [1] => Redis: [0] => OpenSearch: [99] => skip-Xlog: [0] => skip-Redis: [0] => Events: [1]
```